### PR TITLE
Document Fire TV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ that order).
   Fauxmo?
     - Check out
       [`protocol_notes.md`](https://github.com/n8henrie/fauxmo/blob/master/protocol_notes.md)
+- What is the Fire TV Stick support status
+    - Fire TV and Fire TV Stick can not discover WeMo devices
+      but they can be used to control devices discovered by
+      Echo (and other compatible Alexa devices)
 
 ### Installing Python 3.5 with pyenv
 


### PR DESCRIPTION
Confirmed support status with Amazon tech support (2016-08-26).
Also see:

  * http://community.wemothat.com/t5/WEMO-Hardware/Belkin-WEMO-Insight-Switch-No-Longer-Recognized-by-Amazon-Echo-s/m-p/31756#M6537
  * http://www.aftvnews.com/alexa-on-the-amazon-fire-tv-can-now-natively-control-smart-home-devices/#comment-217124