### PR TITLE
Howdy fauxmo updates

### DIFF
--- a/src/fauxmo/fauxmo.py
+++ b/src/fauxmo/fauxmo.py
@@ -41,7 +41,7 @@ def main(config_path_str: str = None, verbosity: int = 20) -> None:
         config_path = pathlib.Path(config_path_str)
     else:
         for config_dir in ('.', "~/.fauxmo", "/etc/fauxmo"):
-            config_path = pathlib.Path(config_dir) / 'config.json'
+            config_path = pathlib.Path(config_dir).expanduser() / 'config.json'
             if config_path.is_file():
                 logger.info(f"Using config: {config_path}")
                 break

--- a/src/fauxmo/utils.py
+++ b/src/fauxmo/utils.py
@@ -24,11 +24,14 @@ def get_local_ip(ip_address: str = None) -> str:
         logger.debug("Attempting to get IP address automatically")
 
         hostname = socket.gethostname()
-        ip_address = socket.gethostbyname(hostname)
+        try:
+            ip_address = socket.gethostbyname(hostname)
+        except socket.gaierror:
+            ip_address = 'unknown'
 
         # Workaround for Linux returning localhost
         # See: SO question #166506 by @UnkwnTech
-        if ip_address in ['127.0.1.1', '127.0.0.1', 'localhost']:
+        if ip_address in ['127.0.1.1', '127.0.0.1', 'localhost', 'unknown']:
             tempsock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             tempsock.connect(('8.8.8.8', 0))
             ip_address = tempsock.getsockname()[0]

--- a/tests/test_fauxmo.py
+++ b/tests/test_fauxmo.py
@@ -51,6 +51,33 @@ def test_turnon(fauxmo_server: pytest.fixture,
     assert resp.status_code == 200
 
 
+def test_getbinarystate(fauxmo_server: pytest.fixture,
+                simplehttpplugin_target: pytest.fixture) -> None:
+    """Test TCP server's "GetBinaryState" action for SimpleHTTPPlugin."""
+    data = (b'Soapaction: "urn:Belkin:service:basicevent:1#GetBinaryState"')
+
+    resp = requests.post('http://127.0.0.1:12345/upnp/control/basicevent1',
+                         data=data)
+    assert resp.status_code == 200
+
+    root = etree.fromstring(resp.text)
+    val = root.find(".//BinaryState").text
+    assert val in ["0", "1"]
+
+
+def test_getfriendlyname(fauxmo_server: pytest.fixture,
+                simplehttpplugin_target: pytest.fixture) -> None:
+    """Test TCP server's "GetFriendlyName" action for SimpleHTTPPlugin."""
+    data = (b'soapaction: "urn:Belkin:service:basicevent:1#GetFriendlyName"')
+
+    resp = requests.post('http://127.0.0.1:12345/upnp/control/basicevent1',
+                         data=data)
+    assert resp.status_code == 200
+
+    root = etree.fromstring(resp.text)
+    assert root.find(".//FriendlyName").text == 'fake switch one'
+
+
 def test_old_config_fails() -> None:
     """Ensure the config for fauxmo < v0.4.0 fails with SystemExit."""
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Description

Here are a handful of changes to improve fauxmo:

1)  Fix bug where config file was not being read from ~/.fauxmo

2)  Add GetBinaryState command to better emulate Wemo functionality. (This command is supported by real Wemos.  It is evidently not used by Echo, but it is used by another script I have developed for my particular application.)

3)  Make header comparison case-insensitive so that fauxmo complies with the UPnP spec.  (Again, this does not affect use with Echo, but it does ensure that fauxmo will play nicely with other UPnP tools.)

4)  Fix bug where fauxmo would fail if locally-configured hostname was not resolvable by DNS

5)  Add test cases for items 2 and 3 above, and add an additional test case for the GetBinaryState command.

I've tested all the above with a) the built-in test suite, b) a real Echo, and c) my project's UPnP based tools (which unfortunately I can't share, sorry).

## Status

**READY**



