### PR TITLE
Add utf-8 to readme parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import re
 from setuptools import setup, find_packages
 
-with open('README.md') as readme_file, open('CHANGELOG.md') as history_file:
+with open('README.md', encoding='utf-8') as readme_file, open('CHANGELOG.md') as history_file:
     readme = readme_file.read()
     history = history_file.read()
 


### PR DESCRIPTION
This fixes a NixOS builder issue due to non-ascii characters in the
readme.

## Related Issues

- [POST method doesn't support raw on/off data](https://github.com/n8henrie/fauxmo/issues/54)

## Todos

- [x] Tests

## Steps to Test or Reproduce
broken:
```bash
wget https://raw.githubusercontent.com/hestela/dot_files/b49f82523982d2b9a004cfe406e553f0dab000e1/nix/pkgs/fauxmo.nix
wget https://raw.githubusercontent.com/hestela/dot_files/master/nix/pkgs/pypandoc.nix
nix-build fauxmo.nix

<clip>
building
Traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 5, in <module>
    readme = readme_file.read()
  File "/nix/store/ljhgdba6n8ag6f8clpi4m9zizm7b8mx3-python3-3.6.5/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcb in position 2080: ordinal not in range(128)

```



fixed:
In NixOS (container should work also).
```bash
wget https://raw.githubusercontent.com/hestela/dot_files/master/nix/pkgs/fauxmo.nix
wget https://raw.githubusercontent.com/hestela/dot_files/master/nix/pkgs/pypandoc.nix
nix-build fauxmo.nix

/nix/store/0p3hzk8sg8amjfxdj4afj4mh035zn5cx-fauxmo-0.4.7
```


