### PR TITLE
Plugin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ strongly recommend that you:
     manually install their dependencies into the appropriate environment, so
     it's important to let other users know exactly what versions you use.
 
+Be aware, when fauxmo loads a plugin, it will add the directory
+containing the plugin to the Python system path, so any other Python
+modules in this directory might be loaded by unscrupulous code.
+
 ### Notable plugin examples
 
 NB: You may need to *manually* install additional dependencies for these to

--- a/src/fauxmo/utils.py
+++ b/src/fauxmo/utils.py
@@ -4,6 +4,7 @@ import importlib.util
 import pathlib
 import socket
 import struct
+import sys
 import uuid
 from types import ModuleType
 
@@ -69,6 +70,7 @@ def module_from_file(modname: str, path_str: str) -> ModuleType:
 
     """
     path = pathlib.Path(path_str).expanduser()
+    sys.path.append(str(path.parents[0]))
     spec = importlib.util.spec_from_file_location(modname, str(path))
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)


### PR DESCRIPTION
## Description

When loading a plugin, append the plugin's directory to sys.path. This allows the plugin to easily load other python files located in the same directory.  Also added a note to README.md regarding the possible security issue.  See discussion in  [#58](https://github.com/n8henrie/fauxmo/issues/58).
