### PR TITLE
add `StartLimitBurst=0`

### DIFF
--- a/extras/fauxmo.service
+++ b/extras/fauxmo.service
@@ -9,6 +9,7 @@ WorkingDirectory=/abs/path/to/dir/fauxmo
 # Fix the paths below:
 ExecStart=/abs/path/to/.venv/bin/fauxmo -c /abs/path/to/fauxmo/config.json -v
 Restart=on-failure
+StartLimitBurst=0
 User=fauxmo
 
 [Install]


### PR DESCRIPTION
Issue encountered: fauxo.service doesn't work sometimes after reboot

journalctl -u fauxmo.service
```
...
Aug 20 18:43:00 machine systemd[1]: Stopped Fauxmo.
Aug 20 18:43:00 machine systemd[1]: fauxmo.service: Start request repeated too quickly.
...
```

Adding `StartLimitBurst=0` disable rate limits on restart, so the Start request repeated too quickly case does not happen anymore.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Status

**READY/IN DEVELOPMENT**

## Related Issues

- [First related issue](https://github.com/n8henrie/fauxmo/issues/1)

## Todos

- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce

E.g.:

```bash
git checkout -b <feature_branch> master
git pull https://github.com/<user>/fauxmo.git <feature_branch>
py.test tests/
```

## Other notes


