### PR TITLE
issue-50 replacing test.support find_unused_port

### DIFF
--- a/src/fauxmo/fauxmo.py
+++ b/src/fauxmo/fauxmo.py
@@ -16,8 +16,8 @@ from functools import partial
 from fauxmo import __version__, logger
 from fauxmo.plugins import FauxmoPlugin
 from fauxmo.protocols import Fauxmo, SSDPServer
-from fauxmo.utils import (get_local_ip, make_udp_sock, module_from_file,
-                          get_unused_port)
+from fauxmo.utils import (get_local_ip, get_unused_port, make_udp_sock,
+                          module_from_file,)
 
 
 def main(config_path_str: str = None, verbosity: int = 20) -> None:

--- a/src/fauxmo/fauxmo.py
+++ b/src/fauxmo/fauxmo.py
@@ -12,12 +12,12 @@ import pathlib
 import signal
 import sys
 from functools import partial
-from test.support import find_unused_port
 
 from fauxmo import __version__, logger
 from fauxmo.plugins import FauxmoPlugin
 from fauxmo.protocols import Fauxmo, SSDPServer
-from fauxmo.utils import get_local_ip, make_udp_sock, module_from_file
+from fauxmo.utils import (get_local_ip, make_udp_sock, module_from_file,
+                          get_unused_port)
 
 
 def main(config_path_str: str = None, verbosity: int = 20) -> None:
@@ -103,7 +103,7 @@ def main(config_path_str: str = None, verbosity: int = 20) -> None:
             logger.debug(f"device config: {repr(device)}")
 
             # Ensure port is `int`, set it if not given (`None`) or 0
-            device["port"] = int(device.get('port', 0)) or find_unused_port()
+            device["port"] = int(device.get('port', 0)) or get_unused_port()
 
             try:
                 plugin = PluginClass(**plugin_vars, **device)

--- a/src/fauxmo/fauxmo.py
+++ b/src/fauxmo/fauxmo.py
@@ -17,7 +17,7 @@ from fauxmo import __version__, logger
 from fauxmo.plugins import FauxmoPlugin
 from fauxmo.protocols import Fauxmo, SSDPServer
 from fauxmo.utils import (get_local_ip, get_unused_port, make_udp_sock,
-                          module_from_file,)
+                          module_from_file)
 
 
 def main(config_path_str: str = None, verbosity: int = 20) -> None:

--- a/src/fauxmo/utils.py
+++ b/src/fauxmo/utils.py
@@ -105,7 +105,8 @@ def make_udp_sock() -> socket.socket:
 
     return sock
 
-def get_unused_port():
+
+def get_unused_port() --> int:
     """
     Temporarily binds a socket to a system assigned unused port.
 

--- a/src/fauxmo/utils.py
+++ b/src/fauxmo/utils.py
@@ -104,3 +104,14 @@ def make_udp_sock() -> socket.socket:
     sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
 
     return sock
+
+def get_unused_port():
+    """
+    Temporarily binds a socket to a system assigned unused port.
+
+    Returns:
+        INT of available port number.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('', 0))
+        return int(sock.getsockname()[1])

--- a/src/fauxmo/utils.py
+++ b/src/fauxmo/utils.py
@@ -106,12 +106,13 @@ def make_udp_sock() -> socket.socket:
     return sock
 
 
-def get_unused_port() --> int:
+def get_unused_port() -> int:
     """
     Temporarily binds a socket to a system assigned unused port.
 
     Returns:
         INT of available port number.
+
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(('', 0))

--- a/tests/test_fauxmo.py
+++ b/tests/test_fauxmo.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from fauxmo import fauxmo
 from fauxmo.plugins.simplehttpplugin import SimpleHTTPPlugin
+from fauxmo.utils import get_unused_port
 
 
 def test_udp_search(fauxmo_server: pytest.fixture) -> None:
@@ -106,3 +107,9 @@ def test_simplehttpplugin(simplehttpplugin_target: pytest.fixture) -> None:
             assert state == "unknown"
 
         device.close()
+
+def test_get_unused_port():
+    available_port = get_unused_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('', available_port))
+        assert int(sock.getsockname()[1]) == available_port

--- a/tests/test_fauxmo.py
+++ b/tests/test_fauxmo.py
@@ -109,11 +109,14 @@ def test_simplehttpplugin(simplehttpplugin_target: pytest.fixture) -> None:
         device.close()
 
 
-def test_get_unused_port() --> None:
+def test_get_unused_port() -> None:
     """
-    Test get_unused_port function in utils.py.  Checks to make sure the port
-    returned by the function is actually available after function is run.
+    Test get_unused_port function in utils.py.
+
+    Checks to make sure the port returned by the function is actually available
+    after function is run.
     Also ensures a socket can be successfully created with the given port.
+
     """
     available_port = get_unused_port()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/tests/test_fauxmo.py
+++ b/tests/test_fauxmo.py
@@ -108,7 +108,13 @@ def test_simplehttpplugin(simplehttpplugin_target: pytest.fixture) -> None:
 
         device.close()
 
-def test_get_unused_port():
+
+def test_get_unused_port() --> None:
+    """
+    Test get_unused_port function in utils.py.  Checks to make sure the port
+    returned by the function is actually available after function is run.
+    Also ensures a socket can be successfully created with the given port.
+    """
     available_port = get_unused_port()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(('', available_port))


### PR DESCRIPTION
## Description

Fixes issue-50 replacing test.support find_unused_port.  Now we are manually checking the system for any available ports and using one returned by the method.  This allows us to not rely on test.support since that isn't part of standard python.

## Status

Ready for review

## Related Issues

- https://github.com/n8henrie/fauxmo/issues/50

## Steps to Test or Reproduce

bash
git checkout issue-50
make test


