### PR TITLE
Exception in callback _SelectorSocketTransport._read_ready()  -- Very ugly fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Fauxmo README
 
+Forked from [n8henrie/fauxmo](https://github.com/n8henrie/fauxmo)
+
+This fork fixes a problem where an Alex device turns on a device and then fails to get a suitable response, and reports an annoying error.  
+This is probably due to a race condition on the Raspberry Pi.    I did not file a pull request since the solution (in /plugins/simplehttpplugin.py )
+is so abysmally ugly and warrants a better solution.
+
 master: [![master branch build status](https://github.com/n8henrie/fauxmo/actions/workflows/python-package.yml/badge.svg?branch=master)](https://github.com/n8henrie/fauxmo/actions/workflows/python-package.yml)
 dev: [![dev branch build status](https://github.com/n8henrie/fauxmo/actions/workflows/python-package.yml/badge.svg?branch=dev)](https://github.com/n8henrie/fauxmo/actions/workflows/python-package.yml)
 

--- a/src/fauxmo/plugins/simplehttpplugin.py
+++ b/src/fauxmo/plugins/simplehttpplugin.py
@@ -178,6 +178,10 @@ class SimpleHTTPPlugin(FauxmoPlugin):
             "on", "off", or "unknown"
 
         """
+        
+        import time
+        time.sleep(2) # Ugly hack from GD that makes ti work much more reliably with Alexa after turn-on
+        
         if self.use_fake_state is True:
             return super().get_state()
 


### PR DESCRIPTION

## Description

When I turn on my faxumo device with Alexa, I usually see an exception
and then the Alex reports an error with the device (even though the device changes state correctly).  

The exception is:
Exception in callback _SelectorSocketTransport._read_ready()
which is down the call chain from
handle_action(msg)

I believe there is a race condition, perhaps because an older Pi takes to long to setup or take down the network connection.  

I have an extremely hacky fix that I am sharing, but this problem does not seem to be widely reported, and the solution is so ugly, that I am not sure it should be integrated and I am sharing it onyl for your information.


## Status

**READY

## Related issue

https://github.com/n8henrie/fauxmo/issues/115


## Other notes

Here's what the error trace looks like (before the ugly fix):
```

2022-07-17 11:01:36 fauxmo:140      INFO     Attempting to get state for raspberry
2022-07-17 11:01:38 asyncio:1274     ERROR    Exception in callback _SelectorSocketTransport._read_ready()
handle: <Handle _SelectorSocketTransport._read_ready() created at /usr/local/lib/python3.6/asyncio/selector_events.py:262>
source_traceback: Object created at (most recent call last):
  File "/usr/local/bin/fauxmo", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/fauxmo/cli.py", line 37, in cli
    main(config_path_str=args.config, verbosity=verbosity)
  File "/usr/local/lib/python3.6/site-packages/fauxmo/fauxmo.py", line 154, in main
    loop.run_forever()
  File "/usr/local/lib/python3.6/asyncio/base_events.py", line 427, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.6/asyncio/base_events.py", line 1432, in _run_once
    handle._run()
  File "/usr/local/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.6/asyncio/selector_events.py", line 680, in _add_reader
    self._loop._add_reader(fd, callback, *args)
  File "/usr/local/lib/python3.6/asyncio/selector_events.py", line 262, in _add_reader
    handle = events.Handle(callback, args, self)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.6/asyncio/selector_events.py", line 732, in _read_ready
    self._protocol.data_received(data)
  File "/usr/local/lib/python3.6/site-packages/fauxmo/protocols.py", line 67, in data_received
    self.handle_action(msg)
  File "/usr/local/lib/python3.6/site-packages/fauxmo/protocols.py", line 145, in handle_action
    state = self.plugin.get_state().casefold()
  File "/usr/local/lib/python3.6/site-packages/fauxmo/plugins/simplehttpplugin.py", line 196, in get_state
    with self.urlopen(req) as resp:
  File "/usr/local/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/local/lib/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/local/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.6/urllib/request.py", line 1346, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/local/lib/python3.6/urllib/request.py", line 1321, in do_open
    r = h.getresponse()
  File "/usr/local/lib/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/local/lib/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/local/lib/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/local/lib/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
ConnectionResetError: [Errno 104] Connection reset by peer

```


