### PR TITLE
Add support for fauxmo devices to be discovered by HomeAssistant

### DIFF
--- a/src/fauxmo/protocols.py
+++ b/src/fauxmo/protocols.py
@@ -81,6 +81,7 @@ class Fauxmo(asyncio.Protocol):
             "<manufacturer>Belkin International Inc.</manufacturer>"
             "<modelName>Emulated Socket</modelName>"
             "<modelNumber>3.1415</modelNumber>"
+            f"<serialNumber>{self.serial}</serialNumber>"
             f"<UDN>uuid:Socket-1_0-{self.serial}</UDN>"
             "<serviceList>"
             "<service>"
@@ -362,6 +363,7 @@ class SSDPServer(asyncio.DatagramProtocol):
 
         discover_patterns = [
             "ST: urn:Belkin:device:**",
+            "ST: urn:Belkin:service:basicevent:1",
             "ST: upnp:rootdevice",
             "ST: ssdp:all",
         ]


### PR DESCRIPTION
## Description

Makes two changes needed for HomeAssistant to discover and manage fauxmo devices:

* HomeAssistant relies on pywemo for device discovery. The pywemo.discover_devices() function sends an ssdp probe using the string "urn:Belkin:service:basicevent:1". This change causes fauxmo to respond to that probe so that pywemo.discover_devices will find fauxmo devices.

* As mentioned in https://github.com/n8henrie/fauxmo/issues/88, HomeAssistant uses the serial number returned by a "real" Wemo to disambiguate devices, if more than one device shares an IP address. This changes causes fauxmo to respond to a setup message with the serial number, so that multiple fauxmo devices will be seen from HomeAssistant.  This change was mentioned in the discussion for Issue 88 but does not appear to have been merged to master.

## Status

**READY

## Related Issues

- [Fauxmo does not work with Home Assistant](https://github.com/n8henrie/fauxmo/issues/88)

## Steps to Test or Reproduce

Unfortunately I don’t have a system that is capable of running `make test-all` (even before my change).  I have, however, manually tested the change against pywemo.discover_devices (from pywemo 0.9.1) and also against HomeAssistant 2023.11.3.
